### PR TITLE
fix: Use Java 17 as source & target compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,9 @@ allprojects {
 
     java {
         withSourcesJar()
+
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     publishing {


### PR DESCRIPTION
This prevents Gradle from publishing wrong values in its enhanced metadata, allowing endec to be properly used in Java 17 projects, like older mods that still support their pre-21 branches.